### PR TITLE
Add LaunchpadEnvironment enum and URL detection utilities

### DIFF
--- a/src/uris.rs
+++ b/src/uris.rs
@@ -4,6 +4,142 @@
 //! "https://api.staging.launchpad.net/".
 
 use std::collections::HashMap;
+use std::fmt;
+
+/// Enum representing different Launchpad environments
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum LaunchpadEnvironment {
+    /// Production environment
+    Production,
+    /// Edge environment (deprecated, redirects to production)
+    Edge,
+    /// QA staging environment
+    QaStaging,
+    /// Staging environment
+    Staging,
+    /// Dogfood environment
+    Dogfood,
+    /// Development environment
+    Dev,
+    /// Test development environment
+    TestDev,
+}
+
+impl LaunchpadEnvironment {
+    /// Get the service root URL for this environment
+    pub fn service_root(&self) -> &'static str {
+        match self {
+            LaunchpadEnvironment::Production => LPNET_SERVICE_ROOT,
+            LaunchpadEnvironment::Edge => LPNET_SERVICE_ROOT,
+            LaunchpadEnvironment::QaStaging => QASTAGING_SERVICE_ROOT,
+            LaunchpadEnvironment::Staging => STAGING_SERVICE_ROOT,
+            LaunchpadEnvironment::Dogfood => DOGFOOD_SERVICE_ROOT,
+            LaunchpadEnvironment::Dev => DEV_SERVICE_ROOT,
+            LaunchpadEnvironment::TestDev => TEST_DEV_SERVICE_ROOT,
+        }
+    }
+
+    /// Get the web root URL for this environment
+    pub fn web_root(&self) -> &'static str {
+        match self {
+            LaunchpadEnvironment::Production => LPNET_WEB_ROOT,
+            LaunchpadEnvironment::Edge => LPNET_WEB_ROOT,
+            LaunchpadEnvironment::QaStaging => QASTAGING_WEB_ROOT,
+            LaunchpadEnvironment::Staging => STAGING_WEB_ROOT,
+            LaunchpadEnvironment::Dogfood => DOGFOOD_WEB_ROOT,
+            LaunchpadEnvironment::Dev => DEV_WEB_ROOT,
+            LaunchpadEnvironment::TestDev => TEST_DEV_WEB_ROOT,
+        }
+    }
+
+    /// Get the alias string for this environment
+    pub fn alias(&self) -> &'static str {
+        match self {
+            LaunchpadEnvironment::Production => "production",
+            LaunchpadEnvironment::Edge => "edge",
+            LaunchpadEnvironment::QaStaging => "qastaging",
+            LaunchpadEnvironment::Staging => "staging",
+            LaunchpadEnvironment::Dogfood => "dogfood",
+            LaunchpadEnvironment::Dev => "dev",
+            LaunchpadEnvironment::TestDev => "test_dev",
+        }
+    }
+
+    /// Try to parse an environment from an alias string
+    pub fn from_alias(alias: &str) -> Option<Self> {
+        match alias {
+            "production" => Some(LaunchpadEnvironment::Production),
+            "edge" => Some(LaunchpadEnvironment::Edge),
+            "qastaging" => Some(LaunchpadEnvironment::QaStaging),
+            "staging" => Some(LaunchpadEnvironment::Staging),
+            "dogfood" => Some(LaunchpadEnvironment::Dogfood),
+            "dev" => Some(LaunchpadEnvironment::Dev),
+            "test_dev" => Some(LaunchpadEnvironment::TestDev),
+            _ => None,
+        }
+    }
+
+    /// Try to determine the environment from a URL
+    pub fn from_url(url: &url::Url) -> Option<Self> {
+        let host = url.host_str()?;
+        let port = url.port();
+
+        // Check for TestDev first (it has a specific port)
+        if port == Some(8085) && (host == "launchpad.test" || host == "api.launchpad.test") {
+            return Some(LaunchpadEnvironment::TestDev);
+        }
+
+        match host {
+            "launchpad.net" | "api.launchpad.net" => Some(LaunchpadEnvironment::Production),
+            "edge.launchpad.net" | "api.edge.launchpad.net" => Some(LaunchpadEnvironment::Edge),
+            "staging.launchpad.net" | "api.staging.launchpad.net" => {
+                Some(LaunchpadEnvironment::Staging)
+            }
+            "qastaging.launchpad.net" | "api.qastaging.launchpad.net" => {
+                Some(LaunchpadEnvironment::QaStaging)
+            }
+            "dogfood.paddev.net" | "api.dogfood.paddev.net" => Some(LaunchpadEnvironment::Dogfood),
+            "launchpad.test" | "api.launchpad.test" => Some(LaunchpadEnvironment::Dev),
+            _ => None,
+        }
+    }
+
+    /// Get all known Launchpad hosts for this environment
+    pub fn hosts(&self) -> &'static [&'static str] {
+        match self {
+            LaunchpadEnvironment::Production => &["launchpad.net", "api.launchpad.net"],
+            LaunchpadEnvironment::Edge => &["edge.launchpad.net", "api.edge.launchpad.net"],
+            LaunchpadEnvironment::QaStaging => {
+                &["qastaging.launchpad.net", "api.qastaging.launchpad.net"]
+            }
+            LaunchpadEnvironment::Staging => {
+                &["staging.launchpad.net", "api.staging.launchpad.net"]
+            }
+            LaunchpadEnvironment::Dogfood => &["dogfood.paddev.net", "api.dogfood.paddev.net"],
+            LaunchpadEnvironment::Dev => &["launchpad.test", "api.launchpad.test"],
+            LaunchpadEnvironment::TestDev => &["launchpad.test", "api.launchpad.test"],
+        }
+    }
+
+    /// Get all environments as a slice
+    pub fn all() -> &'static [LaunchpadEnvironment] {
+        &[
+            LaunchpadEnvironment::Production,
+            LaunchpadEnvironment::Edge,
+            LaunchpadEnvironment::QaStaging,
+            LaunchpadEnvironment::Staging,
+            LaunchpadEnvironment::Dogfood,
+            LaunchpadEnvironment::Dev,
+            LaunchpadEnvironment::TestDev,
+        ]
+    }
+}
+
+impl fmt::Display for LaunchpadEnvironment {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.alias())
+    }
+}
 
 /// The root URL for the production Launchpad API.
 pub const LPNET_SERVICE_ROOT: &str = "https://api.launchpad.net/";
@@ -160,6 +296,24 @@ pub fn web_root_for_service_root(service_root: &str) -> Result<String, Error> {
     Ok(web_root)
 }
 
+/// Check if a URL is a Launchpad URL by checking if it matches any known environment
+pub fn is_launchpad_url(url: &url::Url) -> bool {
+    LaunchpadEnvironment::from_url(url).is_some()
+}
+
+/// Get all known Launchpad hosts from all environments
+pub fn get_known_launchpad_hosts() -> Vec<&'static str> {
+    let mut all_hosts = Vec::new();
+
+    for env in LaunchpadEnvironment::all() {
+        all_hosts.extend(env.hosts());
+    }
+
+    all_hosts.sort_unstable();
+    all_hosts.dedup();
+    all_hosts
+}
+
 #[cfg(test)]
 mod tests {
     #[test]
@@ -217,5 +371,175 @@ mod tests {
             LPNET_SERVICE_ROOT
         );
         assert!(dereference_alias("invalid", &SERVICE_ROOTS).is_err());
+    }
+
+    #[test]
+    fn test_environment_from_url() {
+        use super::*;
+
+        // Test production URLs
+        assert_eq!(
+            LaunchpadEnvironment::from_url(&url::Url::parse("https://launchpad.net/").unwrap()),
+            Some(LaunchpadEnvironment::Production)
+        );
+        assert_eq!(
+            LaunchpadEnvironment::from_url(&url::Url::parse("https://api.launchpad.net/").unwrap()),
+            Some(LaunchpadEnvironment::Production)
+        );
+
+        // Test staging URLs
+        assert_eq!(
+            LaunchpadEnvironment::from_url(
+                &url::Url::parse("https://staging.launchpad.net/").unwrap()
+            ),
+            Some(LaunchpadEnvironment::Staging)
+        );
+        assert_eq!(
+            LaunchpadEnvironment::from_url(
+                &url::Url::parse("https://api.staging.launchpad.net/").unwrap()
+            ),
+            Some(LaunchpadEnvironment::Staging)
+        );
+
+        // Test QA staging URLs
+        assert_eq!(
+            LaunchpadEnvironment::from_url(
+                &url::Url::parse("https://qastaging.launchpad.net/").unwrap()
+            ),
+            Some(LaunchpadEnvironment::QaStaging)
+        );
+        assert_eq!(
+            LaunchpadEnvironment::from_url(
+                &url::Url::parse("https://api.qastaging.launchpad.net/").unwrap()
+            ),
+            Some(LaunchpadEnvironment::QaStaging)
+        );
+
+        // Test dogfood URLs
+        assert_eq!(
+            LaunchpadEnvironment::from_url(
+                &url::Url::parse("https://dogfood.paddev.net/").unwrap()
+            ),
+            Some(LaunchpadEnvironment::Dogfood)
+        );
+        assert_eq!(
+            LaunchpadEnvironment::from_url(
+                &url::Url::parse("https://api.dogfood.paddev.net/").unwrap()
+            ),
+            Some(LaunchpadEnvironment::Dogfood)
+        );
+
+        // Test dev URLs
+        assert_eq!(
+            LaunchpadEnvironment::from_url(&url::Url::parse("https://launchpad.test/").unwrap()),
+            Some(LaunchpadEnvironment::Dev)
+        );
+        assert_eq!(
+            LaunchpadEnvironment::from_url(
+                &url::Url::parse("https://api.launchpad.test/").unwrap()
+            ),
+            Some(LaunchpadEnvironment::Dev)
+        );
+
+        // Test test dev URLs
+        assert_eq!(
+            LaunchpadEnvironment::from_url(
+                &url::Url::parse("http://launchpad.test:8085/").unwrap()
+            ),
+            Some(LaunchpadEnvironment::TestDev)
+        );
+        assert_eq!(
+            LaunchpadEnvironment::from_url(
+                &url::Url::parse("http://api.launchpad.test:8085/").unwrap()
+            ),
+            Some(LaunchpadEnvironment::TestDev)
+        );
+
+        // Test non-Launchpad URLs
+        assert_eq!(
+            LaunchpadEnvironment::from_url(&url::Url::parse("https://github.com/").unwrap()),
+            None
+        );
+        assert_eq!(
+            LaunchpadEnvironment::from_url(&url::Url::parse("https://example.com/").unwrap()),
+            None
+        );
+    }
+
+    #[test]
+    fn test_environment_hosts() {
+        use super::*;
+
+        let prod_hosts = LaunchpadEnvironment::Production.hosts();
+        assert!(prod_hosts.contains(&"launchpad.net"));
+        assert!(prod_hosts.contains(&"api.launchpad.net"));
+
+        let staging_hosts = LaunchpadEnvironment::Staging.hosts();
+        assert!(staging_hosts.contains(&"staging.launchpad.net"));
+        assert!(staging_hosts.contains(&"api.staging.launchpad.net"));
+    }
+
+    #[test]
+    fn test_is_launchpad_url() {
+        use super::*;
+
+        // Test valid Launchpad URLs
+        assert!(is_launchpad_url(
+            &url::Url::parse("https://launchpad.net/ubuntu").unwrap()
+        ));
+        assert!(is_launchpad_url(
+            &url::Url::parse("https://api.launchpad.net/1.0/").unwrap()
+        ));
+        assert!(is_launchpad_url(
+            &url::Url::parse("https://staging.launchpad.net/").unwrap()
+        ));
+        assert!(is_launchpad_url(
+            &url::Url::parse("https://api.staging.launchpad.net/").unwrap()
+        ));
+        assert!(is_launchpad_url(
+            &url::Url::parse("https://dogfood.paddev.net/").unwrap()
+        ));
+        assert!(is_launchpad_url(
+            &url::Url::parse("http://launchpad.test:8085/").unwrap()
+        ));
+
+        // Test non-Launchpad URLs
+        assert!(!is_launchpad_url(
+            &url::Url::parse("https://github.com/").unwrap()
+        ));
+        assert!(!is_launchpad_url(
+            &url::Url::parse("https://example.com/").unwrap()
+        ));
+        assert!(!is_launchpad_url(
+            &url::Url::parse("https://not-launchpad.net/").unwrap()
+        ));
+    }
+
+    #[test]
+    fn test_get_known_launchpad_hosts() {
+        use super::*;
+
+        let hosts = get_known_launchpad_hosts();
+
+        // Check that we have some hosts
+        assert!(!hosts.is_empty());
+
+        // Check for some expected hosts
+        assert!(hosts.contains(&"launchpad.net"));
+        assert!(hosts.contains(&"api.launchpad.net"));
+        assert!(hosts.contains(&"staging.launchpad.net"));
+        assert!(hosts.contains(&"api.staging.launchpad.net"));
+        assert!(hosts.contains(&"dogfood.paddev.net"));
+        assert!(hosts.contains(&"api.dogfood.paddev.net"));
+
+        // Check that hosts are sorted
+        let mut sorted = hosts.clone();
+        sorted.sort_unstable();
+        assert_eq!(hosts, sorted);
+
+        // Check no duplicates
+        let mut deduped = hosts.clone();
+        deduped.dedup();
+        assert_eq!(hosts.len(), deduped.len());
     }
 }


### PR DESCRIPTION
- Add LaunchpadEnvironment enum to represent different Launchpad instances (production, staging, qastaging, dogfood, dev, test_dev, edge)
- Add methods to convert between URLs, aliases, and environments
- Add is_launchpad_url() to check if a URL belongs to Launchpad
- Add get_known_launchpad_hosts() to list all known Launchpad hosts